### PR TITLE
german translation

### DIFF
--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
@@ -19,6 +19,8 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
     @Bind(R.id.singleText) TextView singleText;
 
     SimpleDateFormat simpleDateFormat;
+    SingleDateAndTimePickerDialog.Builder singleBuilder;
+    DoubleDateAndTimePickerDialog.Builder doubleBuilder;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -29,9 +31,18 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
         this.simpleDateFormat = new SimpleDateFormat("EEE d MMM HH:mm", Locale.getDefault());
     }
 
+    @Override
+    protected void onPause(){
+        super.onPause();
+        if(singleBuilder!=null)
+            singleBuilder.close();
+        if(doubleBuilder!=null)
+            doubleBuilder.close();
+    }
+
     @OnClick(R.id.singleLayout)
     public void simpleClicked() {
-        new SingleDateAndTimePickerDialog.Builder(this)
+        singleBuilder=new SingleDateAndTimePickerDialog.Builder(this)
             //.bottomSheet()
             //.curved()
             .title("Simple")
@@ -40,13 +51,13 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
                 public void onDateSelected(Date date) {
                     singleText.setText(simpleDateFormat.format(date));
                 }
-            })
-            .display();
+            });
+        singleBuilder.display();
     }
 
     @OnClick(R.id.doubleLayout)
     public void doubleClicked() {
-        new DoubleDateAndTimePickerDialog.Builder(this)
+        doubleBuilder=new DoubleDateAndTimePickerDialog.Builder(this)
             //.bottomSheet()
             //.curved()
             .title("Double")
@@ -61,6 +72,7 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
                 }
                 doubleText.setText(stringBuilder.toString());
             }
-        }).display();
+        });
+        doubleBuilder.display();
     }
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
@@ -127,7 +127,8 @@ public class BottomSheetHelper {
     }
 
     private void remove() {
-        windowManager.removeView(view);
+        if(view.getWindowToken()!=null)
+            windowManager.removeView(view);
     }
 
     public interface Listener {

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
@@ -220,6 +220,7 @@ public class DoubleDateAndTimePickerDialog {
         private DoubleDateAndTimePickerDialog.Listener listener;
         private boolean bottomSheet;
         private boolean curved;
+        private DoubleDateAndTimePickerDialog dialog;
 
         @Nullable
         private String tab0Text;
@@ -281,8 +282,13 @@ public class DoubleDateAndTimePickerDialog {
         }
 
         public void display() {
-            final DoubleDateAndTimePickerDialog dialog = build();
+            dialog = build();
             dialog.display();
+        }
+
+        public void close() {
+            if(dialog!=null)
+                dialog.close();
         }
     }
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
@@ -24,6 +24,7 @@ public class DoubleDateAndTimePickerDialog {
     private SingleDateAndTimePicker pickerTab1;
     private View tab0;
     private View tab1;
+    private boolean okClicked=false;
 
     @Nullable
     private String tab0Text, tab1Text, title;
@@ -120,6 +121,7 @@ public class DoubleDateAndTimePickerDialog {
                 if (isTab0Visible()) {
                     displayTab1();
                 } else {
+                    okClicked=true;
                     close();
                 }
             }
@@ -159,7 +161,7 @@ public class DoubleDateAndTimePickerDialog {
     }
 
     private void onClose() {
-        if (listener != null) {
+        if (listener != null && okClicked) {
             listener.onDateSelected(Arrays.asList(pickerTab0.getDate(), pickerTab1.getDate()));
         }
     }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
@@ -113,6 +113,7 @@ public class SingleDateAndTimePickerDialog {
 
     public static class Builder {
         private final Context context;
+        private SingleDateAndTimePickerDialog dialog;
 
         @Nullable
         private Listener listener;
@@ -155,8 +156,13 @@ public class SingleDateAndTimePickerDialog {
         }
 
         public void display() {
-            final SingleDateAndTimePickerDialog dialog = build();
+            dialog = build();
             dialog.display();
+        }
+
+        public void close() {
+            if(dialog!=null)
+                dialog.close();
         }
     }
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
@@ -15,6 +15,7 @@ public class SingleDateAndTimePickerDialog {
     private Listener listener;
     private BottomSheetHelper bottomSheetHelper;
     private SingleDateAndTimePicker picker;
+    private boolean okClicked=false;
 
     @Nullable
     private String title;
@@ -52,6 +53,7 @@ public class SingleDateAndTimePickerDialog {
         view.findViewById(R.id.buttonOk).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                okClicked=true;
                 close();
             }
         });
@@ -77,7 +79,7 @@ public class SingleDateAndTimePickerDialog {
     }
 
     private void onClose() {
-        if (listener != null) {
+        if (listener != null && okClicked) {
             listener.onDateSelected(picker.getDate());
         }
     }

--- a/singledateandtimepicker/src/main/res/values-de/strings.xml
+++ b/singledateandtimepicker/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="picker_today">Heute</string>
+</resources>


### PR DESCRIPTION
added german translation 7bfef15

also encountered a problem if the picked Date and Time aren't confirmed with the ok Button.
In this case the picker still uses the Date and Time and returns the value.
In my opinion if for example someone clicks on an area that isn't covered by the dialog he/she wan't to
quit it without choosing a value.
Thias is why i changed the two classes in commit db97030

if the app/activity that uses the picker get's paused via home-button etc. the Dialog get's still shown.
Added ability close the Dialog for single and double dialog. Running on close in onpause now closes the dialog.  
This commit also fixes Bug #3 
commit f6e75b8 