### PR TITLE
changed findIndexOfDate because setting mindate to today didn't work

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -835,17 +835,21 @@ public abstract class WheelPicker extends View {
         if (date == null) {
             return 0;
         }
-        Calendar instance = Calendar.getInstance();
-        Date currentTime = instance.getTime();
-        if (currentTime.compareTo(date) == 0) {
-            return getDefaultItemPosition();
-        }
+
         String formatItem = getFormattedValue(date);
+
+        String today=getFormattedValue(new Date());
+        String stoday=getResources().getString(R.string.picker_today);
+        boolean istoday=today.equals(formatItem);
+
         final int itemCount = adapter.getItemCount();
         for (int i = 0; i < itemCount; ++i) {
             final String object = adapter.getItemText(i);
+
             if (formatItem.equals(object)) {
                 return i;
+            }else if(istoday&&object.equals(stoday)){
+                return getDefaultItemPosition();
             }
         }
         return 0;

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -839,8 +839,9 @@ public abstract class WheelPicker extends View {
         String formatItem = getFormattedValue(date);
 
         String today=getFormattedValue(new Date());
-        String stoday=getResources().getString(R.string.picker_today);
-        boolean istoday=today.equals(formatItem);
+        if(today.equals(formatItem)){
+            return getDefaultItemPosition();
+        }
 
         final int itemCount = adapter.getItemCount();
         for (int i = 0; i < itemCount; ++i) {
@@ -848,8 +849,6 @@ public abstract class WheelPicker extends View {
 
             if (formatItem.equals(object)) {
                 return i;
-            }else if(istoday&&object.equals(stoday)){
-                return getDefaultItemPosition();
             }
         }
         return 0;


### PR DESCRIPTION
Trying to use the minDateRange/maxDateRange didn't work.
With the sample Application it worked.
The problem was that i was using today as the Value for minDateRange.

After some investigation noticed the problem is within the findIndexOfDate function.
The if(currentTime.compareTo(date)....will never be true.
If I set the minDate to the current Time this value will be used when calling
findIndexOfDate. Then the current Time will be placed in currentTime.
When these 2 Dates getting compared several seconds or more could have been
passed. This is why this statement will never be true.

The for loop will always be entered.
Of course the two Strings that are compared inside the for loop will never equal if
the mindate ist today.
Because formatItem contains the actual formated Date.
The right value of the adapter would be R.string.picker_today which is never equal.

Because of that I added another String that contains the FormattedtValue of the actual Date.
The value today and formatItem are checked. If they are equal we're searching for R.string.picker_today.
So if istoday is true and the value of object equals R.string.picker_today the right index will be returned again.

Edit: Commit 529e09c didn't solve the problem really efficently. This is why I made commit 453165.
With the newer commit the for loop isn't entered if minDate is today and getDefaultItemPosition is called directly. Now it's more like your orginial Version but the if statement will we true if minDate is today unlike the Version where the 2 Dates where compared.
