### PR TITLE
Listen to changes on the AM/PM wheel

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -114,6 +114,20 @@ public class SingleDateAndTimePicker extends LinearLayout {
             }
         });
 
+        amPmPicker.setOnAmPmSelectedListener(new WheelAmPmPicker.OnAmPmSelectedListener() {
+            @Override
+            public void onAmSelected(WheelAmPmPicker picker) {
+                updateListener();
+                checkMinMaxDate(picker);
+            }
+
+            @Override
+            public void onPmSelected(WheelAmPmPicker picker) {
+                updateListener();
+                checkMinMaxDate(picker);
+            }
+        });
+        
         updatePicker();
         updateViews();
     }


### PR DESCRIPTION
Currently SingleDateAndTimePicker's listener.onDateChanged won't be called when the AM/PM wheel updates. 

This implements a listener on the Wheel allowing for date changes to propagate when the AM/PM values are selected.