### PR TITLE
Fix afternoon wrap-around in am/pm mode, provider better 12-hour formatting

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -27,6 +27,9 @@ public class SingleDateAndTimePicker extends LinearLayout {
     private static final int VISIBLE_ITEM_COUNT_DEFAULT = 7;
     private static final int PM_HOUR_ADDITION = 12;
 
+    private static final CharSequence FORMAT_24_HOUR = "EEE d MMM H:mm";
+    private static final CharSequence FORMAT_12_HOUR = "EEE d MMM h:mm a";
+
     private WheelDayPicker daysPicker;
     private WheelMinutePicker minutesPicker;
     private WheelHourPicker hoursPicker;
@@ -320,7 +323,7 @@ public class SingleDateAndTimePicker extends LinearLayout {
         int indexOfHour = hoursPicker.findIndexOfDate(date);
         if (indexOfHour != -1) {
             if (isAmPm) {
-                if(calendar.get(Calendar.HOUR_OF_DAY) > WheelHourPicker.MAX_HOUR_AM_PM) {
+                if(calendar.get(Calendar.HOUR_OF_DAY) >= WheelHourPicker.MAX_HOUR_AM_PM) {
                     amPmPicker.setPmSelected();
                 } else {
                     amPmPicker.setAmSelected();
@@ -335,12 +338,11 @@ public class SingleDateAndTimePicker extends LinearLayout {
     }
 
     private void updateListener() {
-        final int hour = hoursPicker.getCurrentHour();
-        final int minute = minutesPicker.getCurrentMinute();
-        final String displayed = daysPicker.getCurrentDay() + " " + hour + ":" + minute;
-
+        final Date date = getDate();
+        CharSequence format = isAmPm ? FORMAT_12_HOUR : FORMAT_24_HOUR;
+        String displayed = DateFormat.format(format, date).toString();
         if (listener != null) {
-            listener.onDateChanged(displayed, getDate());
+            listener.onDateChanged(displayed, date);
         }
     }
 

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelHourPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelHourPicker.java
@@ -12,7 +12,7 @@ public class WheelHourPicker extends WheelPicker {
 
     public static final int MIN_HOUR_DEFAULT = 0;
     public static final int MAX_HOUR_DEFAULT = 23;
-    public static final int MAX_HOUR_AM_PM = 11;
+    public static final int MAX_HOUR_AM_PM = 12;
     public static final int STEP_HOURS_DEFAULT = 1;
 
     private OnHourSelectedListener hoursSelectedListener;
@@ -38,8 +38,16 @@ public class WheelHourPicker extends WheelPicker {
 
     private void initAdapter() {
         final List<String> hours = new ArrayList<>();
-        for (int hour = minHour; hour <= maxHour; hour += hoursStep) {
-            hours.add(getFormattedValue(hour));
+
+        if (isAmPm) {
+            hours.add(getFormattedValue(12));
+            for (int hour = hoursStep; hour < maxHour; hour += hoursStep) {
+                hours.add(getFormattedValue(hour));
+            }
+        } else {
+            for (int hour = minHour; hour <= maxHour; hour += hoursStep) {
+                hours.add(getFormattedValue(hour));
+            }
         }
 
         adapter = new Adapter(hours);
@@ -81,7 +89,7 @@ public class WheelHourPicker extends WheelPicker {
         if (isAmPm) {
             final int hours = date.getHours();
             if (hours >= MAX_HOUR_AM_PM) {
-                date.setHours(hours - MAX_HOUR_AM_PM);
+                date.setHours(hours % 12);
             }
         }
         return super.findIndexOfDate(date);
@@ -150,7 +158,16 @@ public class WheelHourPicker extends WheelPicker {
     }
 
     private int convertItemToHour(Object item) {
-        return Integer.valueOf(String.valueOf(item));
+        Integer hour = Integer.valueOf(String.valueOf(item));
+        if (!isAmPm) {
+            return hour;
+        }
+
+        if (hour == 12) {
+            hour = 0;
+        }
+
+        return hour;
     }
 
     public int getCurrentHour() {


### PR DESCRIPTION
When setting a date in AmPm mode, the hour selector would incorrectly select an hour later for afternoon hours.

Additionally, it is more commonplace for 12-hour clocks to represent the 0th and 12th hour of the day as "12".

This PR addresses both the afternoon bug as well as the more standard formatting for 12-hour clock users. 

I'm open to any/all feedback on the approach, thanks!