### PR TITLE
Enable the bottomSheet() and run the demo app in earlier version of API Level 21 app is crashing #32

### DIFF
--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
@@ -60,7 +60,7 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
         //final Date maxDate = calendar.getTime();
 
         singleBuilder = new SingleDateAndTimePickerDialog.Builder(this)
-                //.bottomSheet()
+                .bottomSheet()
                 //.curved()
 
                 .backgroundColor(Color.BLACK)

--- a/singledateandtimepicker/src/main/res/layout-v21/bottom_sheet_picker_bottom_sheet.xml
+++ b/singledateandtimepicker/src/main/res/layout-v21/bottom_sheet_picker_bottom_sheet.xml
@@ -27,6 +27,7 @@
                 android:layout_height="match_parent"
                 android:layout_gravity="right|center_vertical"
                 android:gravity="center"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:paddingLeft="20dp"
                 android:paddingRight="25dp"
                 android:text="@android:string/ok"


### PR DESCRIPTION
When we run the Demo application by enabling the bottomSheet() inside the file MainActivityWithDoublePicker.java on the line number 63. The application is crashing in android version 4.1.2 and may be earlier all device that API Level 21.

I detected that while SingleDateAndTimePickerDialog constructor is called. Becuase in one of the layout file bottom_sheet_picker_bottom_sheet.xml see the below text view use the android properties that only available after API Level 21 or later version so either remove it or give the support.

android:background="?android:attr/selectableItemBackgroundBorderless"

```
<TextView
                android:id="@+id/buttonOk"
                android:layout_width="wrap_content"
                android:layout_height="match_parent"
                android:layout_gravity="right|center_vertical"
                android:gravity="center"
               android:background="?android:attr/selectableItemBackgroundBorderless"
                android:paddingLeft="20dp"
                android:paddingRight="25dp"
                android:text="@android:string/ok"
                android:textAllCaps="true"
                android:textColor="@color/picker_button_background_selected"
                android:textStyle="bold"
                />
```
By removing this line I can able to run it succesfully in android 4.1.2