### PR TITLE
Window Leak on screen rotation

### DIFF
--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/MainActivityWithDoublePicker.java
@@ -58,9 +58,9 @@ public class MainActivityWithDoublePicker extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
         if (singleBuilder != null)
-            singleBuilder.close();
+            singleBuilder.dismiss();
         if (doubleBuilder != null)
-            doubleBuilder.close();
+            doubleBuilder.dismiss();
     }
 
 

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BaseDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BaseDialog.java
@@ -58,6 +58,10 @@ public abstract class BaseDialog {
         this.isDisplaying = false;
     }
 
+    public void dismiss() {
+        this.isDisplaying = false;
+    }
+
     public boolean isDisplaying() {
         return isDisplaying;
     }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
@@ -124,6 +124,10 @@ public class BottomSheetHelper {
     }, 200);
   }
 
+  public void dismiss(){
+      remove();
+  }
+
   private void remove() {
     if (view.getWindowToken() != null) windowManager.removeView(view);
   }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
@@ -305,6 +305,12 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
     }
 
     @Override
+    public void dismiss(){
+        super.dismiss();
+        bottomSheetHelper.dismiss();
+    }
+
+    @Override
     public void close() {
         super.close();
         bottomSheetHelper.hide();
@@ -527,6 +533,11 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
             if (dialog != null) {
                 dialog.close();
             }
+        }
+
+        public void dismiss(){
+            if(dialog!=null)
+                dialog.dismiss();
         }
     }
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
@@ -221,6 +221,12 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         }
     }
 
+    @Override
+    public void dismiss(){
+        super.dismiss();
+        bottomSheetHelper.dismiss();
+    }
+
     public interface Listener {
         void onDateSelected(Date date);
     }
@@ -405,6 +411,11 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
             if (dialog != null) {
                 dialog.close();
             }
+        }
+
+        public void dismiss(){
+            if(dialog!=null)
+                dialog.dismiss();
         }
     }
 }


### PR DESCRIPTION
Hi,

This is about Issue #53 
I added a dismiss Method that removes the dialog directly without calling hide() to close with
a smooth animation.
The dismiss Method can now be used for example in onPause where a hide/close should
be done directly to prevent window leaks.
close() can still be used for example when onbackpressed would be used to close an open
dialog. In this case it would be closed with the smooth animation.