### PR TITLE
Fix bug height 0 on draw

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -346,6 +346,8 @@ public abstract class WheelPicker extends View {
   @Override
   protected void onDraw(Canvas canvas) {
     if (null != onWheelChangeListener) onWheelChangeListener.onWheelScrolled(scrollOffsetY);
+    if (mItemHeight - mHalfDrawnItemCount <= 0)
+        return
     int drawnDataStartPos = -scrollOffsetY / mItemHeight - mHalfDrawnItemCount;
     for (int drawnDataPos = drawnDataStartPos + selectedItemPosition,
         drawnOffsetPos = -mHalfDrawnItemCount;

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -347,7 +347,7 @@ public abstract class WheelPicker extends View {
   protected void onDraw(Canvas canvas) {
     if (null != onWheelChangeListener) onWheelChangeListener.onWheelScrolled(scrollOffsetY);
     if (mItemHeight - mHalfDrawnItemCount <= 0)
-        return
+        return;
     int drawnDataStartPos = -scrollOffsetY / mItemHeight - mHalfDrawnItemCount;
     for (int drawnDataPos = drawnDataStartPos + selectedItemPosition,
         drawnOffsetPos = -mHalfDrawnItemCount;


### PR DESCRIPTION
When set height to 0 (in a collapse animation in my case) the WheelPicker try to divide for 0 and crash.
Added a check in onDraw