### PR TITLE
Found a way to dramatically improve performance when loading date/tim…

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -734,11 +734,14 @@ public abstract class WheelPicker extends View {
   }
 
   public void setItemTextSize(int size) {
-    mItemTextSize = size;
-    paint.setTextSize(mItemTextSize);
-    computeTextSize();
-    requestLayout();
-    invalidate();
+
+    if (mItemTextSize != size) {
+      mItemTextSize = size;
+      paint.setTextSize(mItemTextSize);
+      computeTextSize();
+      requestLayout();
+      invalidate();
+    }
   }
 
   public int getItemSpace() {


### PR DESCRIPTION
…e picker on older phones. It was calling setItemTextSize too many times when the picker was being updated by other settings. Instead of figuring out when to call setItemTextSize, the call instead looks for changes and only applies them when the value is different.

I was having performance issues with starting the picker. Figured out that it is trying to readjust the text size each time a setting is changed in the picker. This means that it tries to determine the drawn size of more than 800 strings around 20 times. Since the text size rarely changes, this can be avoided by checking for text size changes before recalculating everything.  With this simple change, it dramatically improves the first draw on older phones. 

Thanks for including the last pull request. Very quick! 