### PR TITLE
SingleDatePicker in xml file does not display days. Fixes #93

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
@@ -90,6 +90,7 @@ public class WheelDayPicker extends WheelPicker {
         }
 
         adapter.setData(data);
+        notifyDatasetChanged();
     }
 
     protected String getFormattedValue(Object value) {


### PR DESCRIPTION
Issue:
The issue was caused by setting an empty adapter initially to WheelPicker which caused computeTextSize() to end up with 0 width.

Solution:
notifyDatasetChanged() is called after updating the items in adapter from updateDays() method which will invoke computerTextSize() calculating the correct width.