### PR TITLE
Update russian strings.xml

### DIFF
--- a/singledateandtimepicker/src/main/res/values-ru/strings.xml
+++ b/singledateandtimepicker/src/main/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="picker_today">сегодня</string>
+    <string name="picker_today">Сегодня</string>
     <string name="picker_am">ДП</string>
     <string name="picker_pm">ПП</string>
 </resources>


### PR DESCRIPTION
since english version has this capitalized

https://github.com/florent37/SingleDateAndTimePicker/blob/a4ee9cde434aaf9f3604127a883768d86e431f93/singledateandtimepicker/src/main/res/values/strings.xml#L3

I'd suggest that we have russian version capitalized, too