### PR TITLE
Add current offset check to move event handling in wheel picker

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -489,7 +489,8 @@ public abstract class WheelPicker extends View {
           downPointY = lastPointY = (int) event.getY();
           break;
         case MotionEvent.ACTION_MOVE:
-          if (Math.abs(downPointY - event.getY()) < touchSlop) {
+          if (Math.abs(downPointY - event.getY()) < touchSlop
+                  && computeDistanceToEndPoint(scroller.getFinalY() % mItemHeight) > 0) {
             isClick = true;
             break;
           }


### PR DESCRIPTION
Proposed fix to this scenario:

- user flings wheel picker
- user presses down to stop fling, fling is stopped in a position between two items of picker
- users finger moves a very small amount (within touch slop)
- user lifts finger off picker.
- picker doesnt scroll to nearest item and is stuck in position between two items.

The problem:

- in `WheelPicker` > `onTouchEvent` - the `MotionEvent.ACTION_MOVE` handling sets the flag `isClick = true` if the move event is less than the touch slop. When the MotionEvent.ACTION_UP is called next, the icClick flag prevents correction of the item position. This means if the position is already offset between two items, the wheelpicker never corrects itself and the current value is not updated.

My solution:

I think adding a check to see if there is any distance to correct before setting isClick flag prevents the above issue.