### PR TITLE
Fixed typo in variable name preventing correct field update

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelHourPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelHourPicker.java
@@ -109,7 +109,7 @@ public class WheelHourPicker extends WheelPicker<String> {
         initAdapter();
     }
 
-    public void setHoursStep(int hourStep) {
+    public void setHoursStep(int hoursStep) {
         if (hoursStep >= MIN_HOUR_DEFAULT && hoursStep <= MAX_HOUR_DEFAULT) {
             this.hoursStep = hoursStep;
         }


### PR DESCRIPTION
a typo in 'hoursStep' meant that the value was not being updated