### PR TITLE
fix java.lang.ArithmeticException at WheelPicker.java

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -1068,7 +1068,7 @@ public abstract class WheelPicker<V> extends View {
         @Override
         public V getItem(int position) {
             final int itemCount = getItemCount();
-            return data.get((position + itemCount) % itemCount);
+            return itemCount == 0 ? null : data.get((position + itemCount) % itemCount);
         }
 
         @Override


### PR DESCRIPTION
fix java.lang.ArithmeticException: divide by zero at com.github.florent37.singledateandtimepicker.widget.WheelPicker$Adapter.getItem(WheelPicker.java:1072)