### PR TITLE
Bugfix: if step minutes was set to 15, and we set default time to  45…

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelMinutePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelMinutePicker.java
@@ -54,6 +54,11 @@ public class WheelMinutePicker extends WheelPicker<String> {
         for (int i = 0; i < itemCount; ++i) {
             final String object = adapter.getItemText(i);
             final Integer value = Integer.valueOf(object);
+
+            if (minute == value) {
+                return i;
+            }
+
             if (minute < value) {
                 return i - 1;
             }


### PR DESCRIPTION
**Issue**
If step minutes was set to 15, and we set default time to  45 minutes past the hour like 12:45, then the picker will set itself to 12:00. 

**The fix**
Now it will correctly set to 12:45.
