### PR TITLE
Change the format of picker_selectorColor from integer to color

### DIFF
--- a/singledateandtimepicker/src/main/res/values/attrs.xml
+++ b/singledateandtimepicker/src/main/res/values/attrs.xml
@@ -35,7 +35,7 @@
         <attr name="picker_cyclic" format="boolean"/>
         <attr name="picker_mustBeOnFuture" format="boolean"/>
         <attr name="picker_visibleItemCount" format="integer"/>
-        <attr name="picker_selectorColor" format="integer"/>
+        <attr name="picker_selectorColor" format="color"/>
         <attr name="picker_selectorHeight" format="dimension"/>
         <attr name="picker_displayMonth" format="boolean"/>
         <attr name="picker_displayYears" format="boolean"/>


### PR DESCRIPTION
When trying to add an attribute in xml file to change the selector color of `SingleDateAndTimePicker` such as:
```
        app:picker_selectorColor="#FF8B8B"
```
It didn't work because the type of the attribute was integer instead of color.
I changed it to color and worked perfectly.

