### PR TITLE
Fixed Picker view flashes while opening date picker dialog issue

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
@@ -74,10 +74,11 @@ public class BottomSheetHelper {
             @Override
             public boolean onPreDraw() {
               view.getViewTreeObserver().removeOnPreDrawListener(this);
-                if (listener != null) {
-                    listener.onLoaded(view);
-                }
-              return true;
+              if (listener != null) {
+                listener.onLoaded(view);
+              }
+              animateBottomSheet();
+              return false;
             }
           });
         }
@@ -92,23 +93,6 @@ public class BottomSheetHelper {
 
   public void display() {
     init();
-    handler.postDelayed(new Runnable() {
-      @Override
-      public void run() {
-        final ObjectAnimator objectAnimator =
-            ObjectAnimator.ofFloat(view, View.TRANSLATION_Y, view.getHeight(), 0);
-        objectAnimator.addListener(new AnimatorListenerAdapter() {
-
-          @Override
-          public void onAnimationEnd(Animator animation) {
-            if (listener != null) {
-              listener.onOpen();
-            }
-          }
-        });
-        objectAnimator.start();
-      }
-    }, 200);
   }
 
   public void hide() {
@@ -138,6 +122,21 @@ public class BottomSheetHelper {
 
   private void remove() {
     if (view.getWindowToken() != null) windowManager.removeView(view);
+  }
+
+  private void animateBottomSheet() {
+    final ObjectAnimator objectAnimator =
+        ObjectAnimator.ofFloat(view, View.TRANSLATION_Y, view.getHeight(), 0);
+    objectAnimator.addListener(new AnimatorListenerAdapter() {
+
+      @Override
+      public void onAnimationEnd(Animator animation) {
+        if (listener != null) {
+          listener.onOpen();
+        }
+      }
+    });
+    objectAnimator.start();
   }
 
   public interface Listener {


### PR DESCRIPTION
Fixed the issue: https://github.com/florent37/SingleDateAndTimePicker/issues/215

Cause:
- The date picker view is initialized in `init()` method.
- Once the view has been added to the window, we start the animation to
  bring the view up from bottom of the screen.
- The animation is run with a delay of `200ms`, this causes the picker view
  to be displayed for a fraction of second before the animation starts.
- Ideally, view creation and starting of animation should be in sync.

Fix:
- Moved the animation changes in the `OnPreDrawListener`.
- Now, the animation start will cause the view draw cycle.

After fix:
![date picker fix](https://user-images.githubusercontent.com/41761642/58886955-5529d500-8702-11e9-82e9-372ca5bcf108.gif)