### PR TITLE
get the current date by index rather than parsing the item text

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 
@@ -129,21 +130,8 @@ public class WheelDayPicker extends WheelPicker<DateWithLabel> {
         if (getTodayText().equals(itemText)) {
             date = todayCalendar.getTime();
         } else {
-            try {
-                date = getDateFormat().parse(itemText);
-            } catch (ParseException e) {
-                e.printStackTrace();
-            }
-        }
-
-        if (date != null) {
-            //try to know the year
-            final Calendar dateCalendar = DateHelper.getCalendarOfDate(date);
-
-            todayCalendar.add(Calendar.DATE, (itemPosition - todayPosition));
-
-            dateCalendar.set(Calendar.YEAR, todayCalendar.get(Calendar.YEAR));
-            date = dateCalendar.getTime();
+            todayCalendar.add(Calendar.DAY_OF_YEAR,(itemPosition - todayPosition));
+            date = todayCalendar.getTime();
         }
 
         return date;


### PR DESCRIPTION
Get the current date by index to improve reliability of
dates based on the calendar of the current year. This fixes
a problem where dates would not be selected correctly when
the month of the current year has a different number of days
from the year 1970, for example in a leap year.

fixes #254