### PR TITLE
Fix date picker doesn't resolve date correctly

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/DateHelper.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/DateHelper.java
@@ -59,4 +59,27 @@ public class DateHelper {
     public static int getDay(Date date){
         return getCalendarOfDate(date).get(Calendar.DAY_OF_MONTH);
     }
+
+    public static int compareDateIgnoreTime(Date first, Date second) {
+        Date firstZeroTime = getZeroTimeDate(first);
+        Date secondZeroTime = getZeroTimeDate(second);
+
+        return firstZeroTime.compareTo(secondZeroTime);
+    }
+
+    private static Date getZeroTimeDate(Date date) {
+        Date res = date;
+        Calendar calendar = Calendar.getInstance();
+
+        calendar.setTime( res );
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        res = calendar.getTime();
+
+        return res;
+    }
+
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/DateWithLabel.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/DateWithLabel.java
@@ -2,6 +2,8 @@ package com.github.florent37.singledateandtimepicker.widget;
 
 import android.util.Pair;
 
+import com.github.florent37.singledateandtimepicker.DateHelper;
+
 import java.util.Date;
 
 public class DateWithLabel extends Pair<String, Date> {
@@ -17,12 +19,21 @@ public class DateWithLabel extends Pair<String, Date> {
         super(first, second);
         if (second == null) {
             throw new IllegalArgumentException("null value provided. " +
-                    "first=[" + first + "], second=[" + second + "]");
+                "first=[" + first + "], second=[" + second + "]");
         }
     }
 
     @Override
     public String toString() {
         return first;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof DateWithLabel) {
+            DateWithLabel newDate = (DateWithLabel) o;
+            return first.equals(newDate.first) && DateHelper.compareDateIgnoreTime(second, newDate.second) == 0;
+        }
+        return false;
     }
 }

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelDayPicker.java
@@ -123,7 +123,15 @@ public class WheelDayPicker extends WheelPicker<DateWithLabel> {
         final Calendar todayCalendar = Calendar.getInstance();
         todayCalendar.setTimeZone(DateHelper.getTimeZone());
 
-        final int todayPosition = adapter.getData().indexOf(getTodayText());
+        int todayPosition = -1;
+        final List<DateWithLabel> data = adapter.getData();
+
+        for(int i = 0; i < data.size(); i++) {
+            if (data.get(i).first.equals(getTodayText())) {
+                todayPosition = i;
+                break;
+            }
+        }
 
         if (getTodayText().equals(itemText)) {
             date = todayCalendar.getTime();
@@ -136,10 +144,12 @@ public class WheelDayPicker extends WheelPicker<DateWithLabel> {
     }
 
     public void setTodayText(DateWithLabel today) {
-        int index = adapter.getData().indexOf(getTodayText());
-        if (index != -1) {
-            adapter.getData().set(index, today);
-            notifyDatasetChanged();
+        final List<DateWithLabel> data = adapter.getData();
+        for(int i = 0; i < data.size(); i++) {
+            if (data.get(i).first.equals(getTodayText())) {
+                adapter.getData().set(i, today);
+                notifyDatasetChanged();
+            }
         }
     }
 

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/widget/WheelPicker.java
@@ -715,7 +715,16 @@ public abstract class WheelPicker<V> extends View {
     }
 
     public int getTodayItemPosition() {
-        return adapter.getData().indexOf(getLocalizedString(R.string.picker_today));
+        List<V> list = adapter.getData();
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i) instanceof DateWithLabel) {
+                DateWithLabel dwl = (DateWithLabel) list.get(i);
+                if (dwl.first.equals(getLocalizedString(R.string.picker_today))) {
+                    return i;
+                }
+            }
+        }
+        return 0;
     }
 
     public void setAdapter(Adapter adapter) {


### PR DESCRIPTION
This is with regards issue [#257 ](https://github.com/florent37/SingleDateAndTimePicker/issues/257). Changed logic in retrieving item in adapter data since there are codes that used `indexOf(String)` despite the data type being `DateWithLabel`.