### PR TITLE
Fix crash due to setting default date on the last day of certain months

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -481,7 +481,7 @@ public class SingleDateAndTimePicker extends LinearLayout {
             calendar.setTime(date);
             this.defaultDate = calendar.getTime();
             
-            updateDaysOfMonth();
+            updateDaysOfMonth(calendar);
 
             for (WheelPicker picker : pickers) {
                 picker.setDefaultDate(defaultDate);


### PR DESCRIPTION
Fixes this: https://github.com/florent37/SingleDateAndTimePicker/issues/265

Details:
* `SingleDateAndTimePicker#setDefaultDate(Date)` was calling `updateDaysOfMonth()` which was using the current date by default to update.
* This was causing the adapter inside `WheelDayOfMonthPicker` to be updated with the wrong number of days
* If setting the default date to the last day of a month, that day may be higher than the number of days in the adapter causing IndexOutOfBoundsException.

Tested that this solution for a variety of dates (May 31, Aug 31 2019)