### PR TITLE
Set wheel-angle via XML + fixed wrap-content by adding item-spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Some/most options are also available via XML:
     <com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker
         android:id="@+id/single_day_picker"
         android:layout_width="wrap_content"
-        android:layout_height="230dp"
+        android:layout_height="wrap_content"
+        app:picker_itemSpacing="6dp"
+        app:picker_curvedMaxAngle="45"
         app:picker_curved="true"
         app:picker_selectorColor="@android:color/transparent"
         app:picker_stepSizeHours="2"
@@ -166,6 +168,12 @@ Some/most options are also available via XML:
         app:picker_visibleItemCount="7"
         />
 ```
+
+* picker_itemSpacing: Margin between items. Only has effect with
+  height=wrap-content
+* picker_curvedMaxAngle sets the max angle of top/bottom items. If 45
+  then the visible 'window' of the wheel is a 'quarter' of the circle.
+  If 90 (default) its rolling on a half-circle
 
 Get divider lines around selected by overwriting one or more of
 ```

--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivity.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivity.java
@@ -1,12 +1,9 @@
 package com.github.florent37.sample.singledateandtimepicker;
 
 import android.os.Bundle;
-import android.view.View;
 import android.widget.Toast;
 
 import com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker;
-
-import java.util.Date;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -18,22 +15,18 @@ public class SingleDatePickerMainActivity extends AppCompatActivity {
         setContentView(R.layout.single_date_picker_activity_main);
 
         final SingleDateAndTimePicker singleDateAndTimePicker = findViewById(R.id.single_day_picker);
+        final SingleDateAndTimePicker singleDateAndTimePicker2 = findViewById(R.id.single_day_picker2);
         // Example for setting default selected date to yesterday
 //        Calendar instance = Calendar.getInstance();
 //        instance.add(Calendar.DATE, -1 );
 //        singleDateAndTimePicker.setDefaultDate(instance.getTime());
-        singleDateAndTimePicker.addOnDateChangedListener(new SingleDateAndTimePicker.OnDateChangedListener() {
-            @Override
-            public void onDateChanged(String displayed, Date date) {
-                display(displayed);
-            }
-        });
+        SingleDateAndTimePicker.OnDateChangedListener changeListener = (displayed, date) -> display(displayed);
+        singleDateAndTimePicker.addOnDateChangedListener(changeListener);
+        singleDateAndTimePicker2.addOnDateChangedListener(changeListener);
 
-        findViewById(R.id.toggleEnabled).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                singleDateAndTimePicker.setEnabled(!singleDateAndTimePicker.isEnabled());
-            }
+        findViewById(R.id.toggleEnabled).setOnClickListener(v -> {
+            singleDateAndTimePicker.setEnabled(!singleDateAndTimePicker.isEnabled());
+            singleDateAndTimePicker2.setEnabled(!singleDateAndTimePicker2.isEnabled());
         });
     }
 

--- a/app/src/main/res/layout/single_date_picker_activity_main.xml
+++ b/app/src/main/res/layout/single_date_picker_activity_main.xml
@@ -1,34 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="#FFFFFF"
     android:gravity="center"
-    android:orientation="vertical"
-    >
+    android:orientation="vertical">
 
     <Button
+        android:id="@+id/toggleEnabled"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/toggleEnabled"
-        android:text="toggle enabled"
-        android:layout_marginBottom="100dp"/>
+        android:layout_marginBottom="50dp"
+        android:text="toggle enabled" />
 
     <!-- See also
         app:picker_selectorColor="@android:color/transparent"
         app:picker_stepSizeHours="2"
         app:picker_stepSizeMinutes="5"
         -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="Full half-circle wheel, with only future selection" />
+
     <com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker
         android:id="@+id/single_day_picker"
         android:layout_width="wrap_content"
-        android:layout_height="230dp"
+        android:layout_height="wrap_content"
         app:picker_curved="true"
         app:picker_cyclic="false"
         app:picker_dayCount="31"
+        app:picker_itemSpacing="6dp"
         app:picker_mustBeOnFuture="true"
-        app:picker_visibleItemCount="7"
-        />
+        app:picker_visibleItemCount="9" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="40dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:text="Quarter-circle wheel, with cyclic and past date selection, and larger item spacing. 365 days" />
+
+    <com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker
+        android:id="@+id/single_day_picker2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:picker_curved="true"
+        app:picker_curvedMaxAngle="45"
+        app:picker_cyclic="true"
+        app:picker_dayCount="365"
+        app:picker_itemSpacing="9dp"
+        app:picker_mustBeOnFuture="false"
+        app:picker_visibleItemCount="9" />
 
 </LinearLayout>

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -296,6 +296,18 @@ public class SingleDateAndTimePicker extends LinearLayout {
         }
     }
 
+    public void setItemSpacing(int size) {
+        for (WheelPicker picker : pickers) {
+            picker.setItemSpace(size);
+        }
+    }
+
+    public void setCurvedMaxAngle(int angle) {
+        for (WheelPicker picker : pickers) {
+            picker.setCurvedMaxAngle(angle);
+        }
+    }
+
     public void setCurved(boolean curved) {
         for (WheelPicker picker : pickers) {
             picker.setCurved(curved);
@@ -581,6 +593,8 @@ public class SingleDateAndTimePicker extends LinearLayout {
         setTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_textColor, ContextCompat.getColor(context, R.color.picker_default_text_color)));
         setSelectedTextColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectedTextColor, ContextCompat.getColor(context, R.color.picker_default_selected_text_color)));
         setSelectorColor(a.getColor(R.styleable.SingleDateAndTimePicker_picker_selectorColor, ContextCompat.getColor(context, R.color.picker_default_selector_color)));
+        setItemSpacing(a.getDimensionPixelSize(R.styleable.SingleDateAndTimePicker_picker_itemSpacing, resources.getDimensionPixelSize(R.dimen.wheelSelectorHeight)));
+        setCurvedMaxAngle(a.getInteger(R.styleable.SingleDateAndTimePicker_picker_curvedMaxAngle, WheelPicker.MAX_ANGLE));
         setSelectorHeight(a.getDimensionPixelSize(R.styleable.SingleDateAndTimePicker_picker_selectorHeight, resources.getDimensionPixelSize(R.dimen.wheelSelectorHeight)));
         setTextSize(a.getDimensionPixelSize(R.styleable.SingleDateAndTimePicker_picker_textSize, resources.getDimensionPixelSize(R.dimen.WheelItemTextSize)));
         setCurved(a.getBoolean(R.styleable.SingleDateAndTimePicker_picker_curved, IS_CURVED_DEFAULT));

--- a/singledateandtimepicker/src/main/res/values/attrs.xml
+++ b/singledateandtimepicker/src/main/res/values/attrs.xml
@@ -32,8 +32,10 @@
         <attr name="picker_selectedTextColor" format="color"/>
         <attr name="picker_textSize" format="dimension"/>
         <attr name="picker_curved" format="boolean"/>
+        <attr name="picker_curvedMaxAngle" format="integer"/>
         <attr name="picker_cyclic" format="boolean"/>
         <attr name="picker_mustBeOnFuture" format="boolean"/>
+        <attr name="picker_itemSpacing" format="dimension"/>
         <attr name="picker_visibleItemCount" format="integer"/>
         <attr name="picker_selectorColor" format="color"/>
         <attr name="picker_selectorHeight" format="dimension"/>


### PR DESCRIPTION
Added two features

Set size of visible circle to quarter circle by:
* app:picker_curvedMaxAngle="45"

Set item-spacing, allowing the use of wrap-content, via 
* app:picker_itemSpacing="6dp"

Extended demo-app example in demo-activity so there is now two wheels with different settings.

PS: Florent, I do apologize for forgot to mention something in my last change request that you merged and released into 2.2.1. If 'mustBeFuture' is true I no longer show past dates, by changing generator in WheelDayPicker. I didn't make it into a xml-property whether to show past dates, because i think this is always a better behaviour. But if you ran the demo-app, you would have noticed, so I guess you were okay with it.

I also think I'm done now, ie. no more changes. I couldn't figure out the Math last week and the draw-code for changing angles, but now I managed to nail it.

PPS: 
There's a bug in the code, that is unrelated to this change, in that sometimes on some specific sizes, the top and bottom item in the wheel are drawn with full opacity. The wheel-sizes in the demo, doesn't provoke this bug, and I couldn't find the source of the bug. Hence its still there