### PR TITLE
Make dialogs focusable to support automation testing

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/BottomSheetHelper.java
@@ -28,6 +28,8 @@ public class BottomSheetHelper {
   private Handler handler;
   private WindowManager windowManager;
 
+  private boolean focusable;
+
   public BottomSheetHelper(Context context, int layoutId) {
     this.context = context;
     this.layoutId = layoutId;
@@ -43,12 +45,14 @@ public class BottomSheetHelper {
 
           view = LayoutInflater.from(context).inflate(layoutId, null, true);
 
+          // Don't let it grab the input focus if focusable is false
+          int flags = focusable ? 0 : WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
+
           WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams(
               // Shrink the window to wrap the content rather than filling the screen
               WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT,
               WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
-              // Don't let it grab the input focus
-              WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+              flags,
               // Make the underlying application window visible through any transparent parts
               PixelFormat.TRANSLUCENT);
 
@@ -89,6 +93,10 @@ public class BottomSheetHelper {
   public BottomSheetHelper setListener(Listener listener) {
     this.listener = listener;
     return this;
+  }
+
+  public void setFocusable(boolean focusable) {
+    this.focusable = focusable;
   }
 
   public void display() {

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/DoubleDateAndTimePickerDialog.java
@@ -417,6 +417,11 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
         return this;
     }
 
+    public DoubleDateAndTimePickerDialog setFocusable(boolean focusable) {
+        bottomSheetHelper.setFocusable(focusable);
+        return this;
+    }
+
     private DoubleDateAndTimePickerDialog setTimeZone(TimeZone timeZone) {
         dateHelper.setTimeZone(timeZone);
         pickerTab0.setTimeZone(timeZone);
@@ -538,6 +543,7 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
         private boolean tab1Days = true;
         private boolean tab1Hours = true;
         private boolean tab1Minutes = true;
+        private boolean focusable = false;
         private TimeZone timeZone;
 
         public Builder(Context context) {
@@ -695,6 +701,11 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
             return this;
         }
 
+        public DoubleDateAndTimePickerDialog.Builder focusable() {
+            this.focusable = true;
+            return this;
+        }
+
         public DoubleDateAndTimePickerDialog build() {
             final DoubleDateAndTimePickerDialog dialog = new DoubleDateAndTimePickerDialog(context, bottomSheet)
                     .setTitle(title)
@@ -722,7 +733,8 @@ public class DoubleDateAndTimePickerDialog extends BaseDialog {
                     .setCustomLocale(customLocale)
                     .setMustBeOnFuture(mustBeOnFuture)
                     .setSecondDateAfterFirst(secondDateAfterFirst)
-                    .setTimeZone(timeZone);
+                    .setTimeZone(timeZone)
+                    .setFocusable(focusable);
 
             if (mainColor != null) {
                 dialog.setMainColor(mainColor);

--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/dialog/SingleDateAndTimePickerDialog.java
@@ -292,6 +292,11 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         return this;
     }
 
+    public SingleDateAndTimePickerDialog setFocusable(boolean focusable) {
+        bottomSheetHelper.setFocusable(focusable);
+        return this;
+    }
+
     private SingleDateAndTimePickerDialog setTimeZone(TimeZone timeZone) {
         dateHelper.setTimeZone(timeZone);
         return this;
@@ -361,6 +366,7 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
         private boolean displayDaysOfMonth = false;
         private boolean displayYears = false;
         private boolean displayMonthNumbers = false;
+        private boolean focusable = false;
 
         @Nullable
         private Boolean isAmPm;
@@ -530,6 +536,11 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
             return this;
         }
 
+        public Builder focusable() {
+            this.focusable = true;
+            return this;
+        }
+
         public SingleDateAndTimePickerDialog build() {
             final SingleDateAndTimePickerDialog dialog = new SingleDateAndTimePickerDialog(context, bottomSheet)
                     .setTitle(title)
@@ -552,7 +563,8 @@ public class SingleDateAndTimePickerDialog extends BaseDialog {
                     .setDayFormatter(dayFormatter)
                     .setCustomLocale(customLocale)
                     .setMustBeOnFuture(mustBeOnFuture)
-                    .setTimeZone(timeZone);
+                    .setTimeZone(timeZone)
+                    .setFocusable(focusable);
 
             if (mainColor != null) {
                 dialog.setMainColor(mainColor);


### PR DESCRIPTION
**Context:**
- Some automation testing framework like Appium and Selenuim uses Android UI
  Automator Viewer tool to capture and process view hierarchy data.
- Android UI Automator Viewer can only capture view hierarchy from focusable
  windows.
- Our DateAndTimePickerDialogs are added to window with FLAG_NOT_FOCUSABLE
  flag. Due to this all DateAndTimePickerDialogs are not focusable and so
  Android UI Automator Viewer not able to capture them in a view hierarchy.
- Such dialogs are not accessible from automation testing frameworks
  like Appium and Selenuim.

**Changes Details:**
- To make DateAndTimePickerDialog views accessible from UI Automator Viewer,
  need to make the dialogs focusable.
- Added support to make DateAndTimePickerDialog focusable by using below ways:
  - SingleDateAndTimePickerDialog.Builder#focusable()
  - SingleDateAndTimePickerDialog#setFocusable(boolean)
  - DoubleDateAndTimePickerDialog.Builder#focusable()
  - DoubleDateAndTimePickerDialog#setFocusable(boolean)

**References:**
- http://appium.io/docs/en/drivers/android-uiautomator/
- https://seleniumbycharan.com/2016/08/07/finding-elements-using-uiautomatorviewer/

**UI Automator View hierarchy:**
**Before:**
![uibefore](https://user-images.githubusercontent.com/51375799/84409809-69fd4a80-ac2b-11ea-9301-09b8aec60b21.png)


**After:**
![uiafter](https://user-images.githubusercontent.com/51375799/84409774-679af080-ac2b-11ea-9350-9321491ef53f.png)
