### PR TITLE
Revert "Removed unnecessary margins and use padding instead. Force th…

### DIFF
--- a/singledateandtimepicker/src/main/res/layout/single_day_and_time_picker.xml
+++ b/singledateandtimepicker/src/main/res/layout/single_day_and_time_picker.xml
@@ -15,72 +15,59 @@
 
         <com.github.florent37.singledateandtimepicker.widget.WheelDayPicker
             android:id="@+id/daysPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="3"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingRight="5dp"
-            android:paddingLeft="5dp"
             app:wheel_atmospheric="true"
-            app:wheel_item_align="right"
-            />
+            app:wheel_item_align="right" />
 
         <com.github.florent37.singledateandtimepicker.widget.WheelDayOfMonthPicker
             android:id="@+id/daysOfMonthPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="2"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
             app:wheel_atmospheric="true"
             app:wheel_item_align="right" />
 
         <com.github.florent37.singledateandtimepicker.widget.WheelMonthPicker
             android:id="@+id/monthPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="3"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
             app:wheel_atmospheric="true"
             app:wheel_item_align="right" />
 
         <com.github.florent37.singledateandtimepicker.widget.WheelYearPicker
             android:id="@+id/yearPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="2"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
             app:wheel_atmospheric="true"
             app:wheel_item_align="right"
-            android:paddingLeft="5dp"
-            android:paddingRight="15dp"/>
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"/>
 
         <com.github.florent37.singledateandtimepicker.widget.WheelHourPicker
             android:id="@+id/hoursPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="1"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingLeft="10dp"
-            android:paddingRight="10dp"
+            android:layout_marginLeft="30dp"
+            android:layout_marginRight="30dp"
             app:wheel_atmospheric="true"
             app:wheel_item_align="center" />
 
         <com.github.florent37.singledateandtimepicker.widget.WheelMinutePicker
             android:id="@+id/minutesPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="1"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingLeft="10dp"
-            android:paddingRight="10dp"
             app:wheel_atmospheric="true"
             app:wheel_item_align="center" />
 
         <com.github.florent37.singledateandtimepicker.widget.WheelAmPmPicker
             android:id="@+id/amPmPicker"
-            android:layout_width="0dp"
-            android:layout_weight ="1"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:paddingLeft="10dp"
-            android:paddingRight="5dp"
+            android:paddingLeft="30dp"
             app:wheel_atmospheric="true"
             app:wheel_item_align="center"
             app:wheel_visible_item_count="2" />


### PR DESCRIPTION
I suggest reverting 2.2.5, hence this pull-request to make it easy for you if you accept. 

2.2.5 does not produce a very nice result. Both the sample app and my production app looks much worse, when the picker view is full width. I want my production to have the divider line to the edges, like the sample app and like for instance Androids default settings app where lines are highlighted to phone edge. Therefore I cannot just add padding to the outer picker view. 

If we are to support padding of the inner views, we could add inner view resource dimension for the padding, but I'm not convinced it is worth it. However Mannon (the author) could add such and leave the default production version of the picker unchanged, and all would be happy :)